### PR TITLE
Replace Windows line endings with proper (Unix) ones.

### DIFF
--- a/src/ClassNameResolver.php
+++ b/src/ClassNameResolver.php
@@ -49,7 +49,8 @@ class ClassNameResolver
 
     private function getNamespaceFromPath(string $path): string
     {
-        $fileSource = file_get_contents($path);
+        //Need to convert Windows line endings to proper ones
+        $fileSource = str_replace("\r\n", "\r", file_get_contents($path));
 
         preg_match('#^namespace\s+(.+?);$#sm', $fileSource, $matches);
 


### PR DESCRIPTION
## Overview
- [x] I have performed a self review of my code
- [x] I have made corresponding changes to the documentation
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient logging
<!-- Remove the below if this project doesn't have tests (maybe it should?) -->
- [x] New and existing tests pass locally with my changes
- [ ] The code modified as part of this PR has been covered with tests

### Problem statement
Windows uses \r\n line endings which do not work with the regex used to find the namespace.

### Solution
Replace Windows line endings with Unix ones.

### Dependencies
None

### Test procedures
Use in a project that is being maintained on a Windows machine

### Links
None

## Deployment

### Migrations
No

### Environment variables
None

### Deployment notes
Code change only
